### PR TITLE
Update _tags to reflect current _oasis file

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: dcada1e9e9e678f87b4c8e5862a5f043)
+# DO NOT EDIT (digest: 47cc0f1473362d76c1a3dc63da04c77a)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -14,12 +14,12 @@ true: annot, bin_annot
 ".git": not_hygienic
 "_darcs": -traverse
 "_darcs": not_hygienic
-# Library journald
-"lib/journald.cmxs": use_journald
-<lib/journald.{cma,cmxa}>: oasis_library_journald_cclib
-"lib/libjournald_stubs.lib": oasis_library_journald_cclib
-"lib/dlljournald_stubs.dll": oasis_library_journald_cclib
-"lib/libjournald_stubs.a": oasis_library_journald_cclib
-"lib/dlljournald_stubs.so": oasis_library_journald_cclib
-<lib/journald.{cma,cmxa}>: use_libjournald_stubs
+# Library systemd
+"lib/systemd.cmxs": use_systemd
+<lib/systemd.{cma,cmxa}>: oasis_library_systemd_cclib
+"lib/libsystemd_stubs.lib": oasis_library_systemd_cclib
+"lib/dllsystemd_stubs.dll": oasis_library_systemd_cclib
+"lib/libsystemd_stubs.a": oasis_library_systemd_cclib
+"lib/dllsystemd_stubs.so": oasis_library_systemd_cclib
+<lib/systemd.{cma,cmxa}>: use_libsystemd_stubs
 # OASIS_STOP

--- a/opam
+++ b/opam
@@ -14,3 +14,8 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "systemd"]
 depends: "ocamlfind"
+depexts: [
+  [["debian"] ["libsystemd-dev"]]
+  [["ubuntu"] ["libsystemd-dev"]]
+  [["centos"] ["systemd-devel"]]
+]


### PR DESCRIPTION
Without this, the linking step fails when trying to link against `systemd.cmxa`

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
