### PR TITLE
Fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 sudo: required
+dist: trusty
 before_install:
    - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
    - sudo apt-get update -qq
-   - sudo apt-get install libsystemd-daemon-dev libsystemd-journal-dev libsystemd-dev
+   - sudo apt-get install libgcrypt20 liblzma5 libselinux1
+   - wget "http://archive.ubuntu.com/ubuntu/ubuntu/pool/main/s/systemd/libsystemd0_219-7ubuntu3_amd64.deb"
+   - wget "http://archive.ubuntu.com/ubuntu/ubuntu/pool/main/s/systemd/libsystemd-dev_219-7ubuntu3_amd64.deb"
+   - sudo dpkg -i libsystemd0_219-7ubuntu3_amd64.deb libsystemd-dev_219-7ubuntu3_amd64.deb
 script: bash -ex .travis-opam.sh
 env:
   -  SYSTEMD_BUILD=1 OCAML_VERSION=4.02


### PR DESCRIPTION
Manually download the system packages and install their dependencies.

This is a workaround for building this package with Travis without using a Docker container, that @mseri found out.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>