### PR TITLE
Hack in missing dependency on Unix

### DIFF
--- a/_tags
+++ b/_tags
@@ -22,4 +22,5 @@ true: annot, bin_annot
 "lib/libsystemd_stubs.a": oasis_library_systemd_cclib
 "lib/dllsystemd_stubs.so": oasis_library_systemd_cclib
 <lib/systemd.{cma,cmxa}>: use_libsystemd_stubs
+<lib/daemon.ml{,i}>: use_unix
 # OASIS_STOP


### PR DESCRIPTION
Provides compatibility to silence the alert proposed in ocaml/ocaml#11198. The change is compatible with previous OCaml releases, but it's obviously not worth merging this unless/until the OCaml PR is accepted.